### PR TITLE
Lunchtime stab at adding temporary halts on payments

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub schedule: Vec<Payment>,
+    pub admin_address: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -22,6 +23,8 @@ pub struct Payment {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Pay {},
+    HaltPayments { recipient: String },
+    StartPayments { recipient: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::msg::Payment;
-use cosmwasm_std::{StdResult, Storage};
+use cosmwasm_std::{Addr, Empty, StdResult, Storage};
 use cw_storage_plus::{Item, Map, U64Key};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -22,3 +22,6 @@ pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     PAYMENT_COUNT.save(store, &id)?;
     Ok(id)
 }
+
+pub const ADMIN_ADDRESS: Item<Addr> = Item::new("admin_address");
+pub const HALTED_PAYEES: Map<Addr, Empty> = Map::new("halted_payees");


### PR DESCRIPTION
Had a spare half hour. Initially went the route of removing payments but that approach would result in dodgy behaviour (I think!) when the following scenario occurs:

- Halt a payment because of non delivery _before payment date_
- Resolve dispute _before payment date_
- Wish to reinstate payment _before payment date_

Therefore the non-destructive approach with filtering seemed to make more sense.

Hence putting it in a separate piece of state.

TODO:

- Needs some unit tests
- Versions are out-of-date so need to bump & fix

Relates to #5 